### PR TITLE
Avoid race setting call error

### DIFF
--- a/rpc.go
+++ b/rpc.go
@@ -283,6 +283,9 @@ func (c *Client) setErr(ctx context.Context, err error) {
 		c.callMu.Lock()
 		defer c.callMu.Unlock()
 		for _, c := range c.calls {
+			if c.err != nil {
+				continue
+			}
 			c.err = err
 			c.finalize()
 		}
@@ -420,8 +423,10 @@ func (c *Client) in(ctx context.Context) {
 		}
 		// Grab call mutex to avoid racing setting error concurrently with setErr.
 		c.callMu.Lock()
-		call.err = err
-		call.finalize()
+		if call.err == nil {
+			call.err = err
+			call.finalize()
+		}
 		c.callMu.Unlock()
 	}
 }


### PR DESCRIPTION
It was possible that both setErr() called by out() and setting a call error by in() would cause a data race.  Avoid this by acquiring the client's call mutex whenever a processed call must be finalized.

There are other instances of finalizing the error before the call is ever added to the client's calls map or touched by in/out.  These don't need to set the error under the call mutex.  Comment each of these cases.