### PR TITLE
Avoid double finalize and racing setting err

### DIFF
--- a/rpc.go
+++ b/rpc.go
@@ -69,9 +69,10 @@ type call struct {
 }
 
 func (c *call) finalize() {
-	if atomic.CompareAndSwapUint32(&c.finalized, 0, 1) {
-		c.done <- c
+	if !atomic.CompareAndSwapUint32(&c.finalized, 0, 1) {
+		panic("wsrpc: double call finalization")
 	}
+	c.done <- c
 }
 
 func (c *call) Result() (interface{}, error) {


### PR DESCRIPTION
There was a data race between out() -> setErr() setting a call error and
finalizing the call while it held the calls mutex, with Client.Go also
performing the finalization on the error without the mutex acquired.  Extend
the critical section so that finalize is only called once.